### PR TITLE
Delete media files and storage folder on media delete

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -633,7 +633,7 @@ var doc = `{
                 }
             }
         },
-        "/medias/{media_id}/stream/playlists/{filename}": {
+        "/medias/{media_id}/stream/{filename}": {
             "get": {
                 "description": "Get HLS playlist file of a media",
                 "produces": [

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -622,7 +622,7 @@
                 }
             }
         },
-        "/medias/{media_id}/stream/playlists/{filename}": {
+        "/medias/{media_id}/stream/{filename}": {
             "get": {
                 "description": "Get HLS playlist file of a media",
                 "produces": [

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -564,7 +564,7 @@ paths:
       summary: Add attachment to a media
       tags:
       - Attachments
-  /medias/{media_id}/stream/playlists/{filename}:
+  /medias/{media_id}/stream/{filename}:
     get:
       description: Get HLS playlist file of a media
       operationId: getMediaPlaylistFile

--- a/api/medias.go
+++ b/api/medias.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dreamvo/gilfoyle/ent"
 	_ "github.com/dreamvo/gilfoyle/ent"
 	"github.com/dreamvo/gilfoyle/ent/media"
+	"github.com/dreamvo/gilfoyle/ent/mediafile"
 	"github.com/dreamvo/gilfoyle/ent/schema"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -124,6 +125,23 @@ func (s *Server) deleteMedia(ctx *gin.Context) {
 	v, _ := s.db.Media.Get(context.Background(), parsedUUID)
 	if v == nil {
 		util.NewError(ctx, http.StatusNotFound, ErrResourceNotFound)
+		return
+	}
+
+	if v.Status == media.StatusProcessing {
+		util.NewError(ctx, http.StatusForbidden, errors.New("you can't delete a media while it's in processing state"))
+		return
+	}
+
+	_, err = s.db.MediaFile.Delete().Where(mediafile.HasMediaWith(media.ID(parsedUUID))).Exec(context.Background())
+	if err != nil {
+		util.NewError(ctx, http.StatusInternalServerError, errors.Unwrap(err))
+		return
+	}
+
+	err = s.storage.Delete(context.Background(), parsedUUID.String())
+	if err != nil {
+		util.NewError(ctx, http.StatusInternalServerError, errors.Unwrap(err))
 		return
 	}
 

--- a/api/medias.go
+++ b/api/medias.go
@@ -15,7 +15,7 @@ import (
 )
 
 type CreateMedia struct {
-	Title string `json:"title" validate:"required,gte=1,lte=255" example:"Sheep Discovers How To Use A Trampoline"`
+	Title string `json:"title" validate:"required,gte=1,lte=200" example:"Sheep Discovers How To Use A Trampoline"`
 }
 
 type UpdateMedia struct {

--- a/api/medias_test.go
+++ b/api/medias_test.go
@@ -167,26 +167,6 @@ func TestMedias(t *testing.T) {
 	})
 
 	t.Run("GET /medias/:id", func(t *testing.T) {
-		t.Run("should return error for invalid UUID", func(t *testing.T) {
-			dbClient := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
-			defer func() { _ = dbClient.Close() }()
-
-			s := NewServer(Options{
-				Database: dbClient,
-				Logger:   zap.NewExample(),
-			})
-
-			res, err := testutils.Send(s.router, http.MethodGet, "/medias/uuid", nil)
-			assert.NoError(t, err, "should be equal")
-
-			var body util.ErrorResponse
-			_ = json.NewDecoder(res.Body).Decode(&body)
-
-			assert.Equal(t, 400, res.Result().StatusCode, "should be equal")
-			assert.Equal(t, 400, body.Code)
-			assert.Equal(t, "invalid UUID provided", body.Message)
-		})
-
 		t.Run("should return media", func(t *testing.T) {
 			dbClient := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
 			defer func() { _ = dbClient.Close() }()
@@ -214,6 +194,46 @@ func TestMedias(t *testing.T) {
 			assert.Equal(t, 200, res.Result().StatusCode, "should be equal")
 			assert.Equal(t, 200, body.Code)
 			assert.Equal(t, v.Title, body.Data.Title)
+		})
+
+		t.Run("should return error for invalid UUID", func(t *testing.T) {
+			dbClient := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+			defer func() { _ = dbClient.Close() }()
+
+			s := NewServer(Options{
+				Database: dbClient,
+				Logger:   zap.NewExample(),
+			})
+
+			res, err := testutils.Send(s.router, http.MethodGet, "/medias/uuid", nil)
+			assert.NoError(t, err, "should be equal")
+
+			var body util.ErrorResponse
+			_ = json.NewDecoder(res.Body).Decode(&body)
+
+			assert.Equal(t, 400, res.Result().StatusCode, "should be equal")
+			assert.Equal(t, 400, body.Code)
+			assert.Equal(t, "invalid UUID provided", body.Message)
+		})
+
+		t.Run("should return error for non-existing media", func(t *testing.T) {
+			dbClient := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+			defer func() { _ = dbClient.Close() }()
+
+			s := NewServer(Options{
+				Database: dbClient,
+				Logger:   zap.NewExample(),
+			})
+
+			res, err := testutils.Send(s.router, http.MethodGet, "/medias/7446a090-8a5c-42ac-83d8-12d19ee5133d", nil)
+			assert.NoError(t, err, "should be equal")
+
+			var body util.ErrorResponse
+			_ = json.NewDecoder(res.Body).Decode(&body)
+
+			assert.Equal(t, 404, res.Result().StatusCode, "should be equal")
+			assert.Equal(t, 404, body.Code)
+			assert.Equal(t, ErrResourceNotFound.Error(), body.Message)
 		})
 	})
 
@@ -361,11 +381,35 @@ func TestMedias(t *testing.T) {
 			assert.Equal(t, 400, res.Result().StatusCode, "should be equal")
 			assert.Equal(t, "Some parameters are missing or invalid", body.Message)
 			assert.Equal(t, map[string]string{
-				"title": "Title must be at maximum 255 characters in length",
+				"title": "Title must be at maximum 200 characters in length",
 			}, body.Fields)
 		})
 
 		t.Run("should return validation error (2)", func(t *testing.T) {
+			dbClient := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+			defer func() { _ = dbClient.Close() }()
+
+			s := NewServer(Options{
+				Database: dbClient,
+				Logger:   zap.NewExample(),
+			})
+
+			res, err := testutils.Send(s.router, http.MethodPost, "/medias", CreateMedia{
+				Title: "",
+			})
+			assert.NoError(t, err, "should be equal")
+
+			var body util.ValidationErrorResponse
+			_ = json.NewDecoder(res.Body).Decode(&body)
+
+			assert.Equal(t, 400, res.Result().StatusCode, "should be equal")
+			assert.Equal(t, "Some parameters are missing or invalid", body.Message)
+			assert.Equal(t, map[string]string{
+				"title": "Title is a required field",
+			}, body.Fields)
+		})
+
+		t.Run("should return validation error (3)", func(t *testing.T) {
 			dbClient := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
 			defer func() { _ = dbClient.Close() }()
 
@@ -433,7 +477,7 @@ func TestMedias(t *testing.T) {
 			assert.NoError(t, err)
 
 			res, err := testutils.Send(s.router, http.MethodPatch, "/medias/"+m.ID.String(), CreateMedia{
-				Title: "Vitae sunt aspernatur quia sunt blanditiis at et excepturi. Doloribus non ut minus saepe. Quas enim minus modi possimus. Blanditiis eius in ipsam incidunt rem et. Rerum blanditiis consequatur facilis eos quia. Sed autem inventore iure ducimus voluptas voluptas.",
+				Title: "Vitae sunt aspernatur quia sunt blanditiis at et excepturi. Doloribus non ut minus saepe. Quas enim minus modi possimus. Blanditiis eius in ipsam incidunt rem et. Rerum blanditiis consequatur facilis55",
 			})
 			assert.NoError(t, err, "should be equal")
 
@@ -443,11 +487,50 @@ func TestMedias(t *testing.T) {
 			assert.Equal(t, 400, res.Result().StatusCode, "should be equal")
 			assert.Equal(t, "Some parameters are missing or invalid", body.Message)
 			assert.Equal(t, map[string]string{
-				"title": "Title must be at maximum 255 characters in length",
+				"title": "Title must be at maximum 200 characters in length",
 			}, body.Fields)
 		})
 
-		t.Run("should return validation error because of bad UUID", func(t *testing.T) {})
-		t.Run("should return resource not found", func(t *testing.T) {})
+		t.Run("should return error because of bad UUID", func(t *testing.T) {
+			dbClient := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+			defer func() { _ = dbClient.Close() }()
+
+			s := NewServer(Options{
+				Database: dbClient,
+				Logger:   zap.NewExample(),
+			})
+
+			res, err := testutils.Send(s.router, http.MethodPatch, "/medias/uuid", CreateMedia{
+				Title: "foo",
+			})
+			assert.NoError(t, err)
+
+			var body util.ErrorResponse
+			_ = json.NewDecoder(res.Body).Decode(&body)
+
+			assert.Equal(t, 400, body.Code)
+			assert.Equal(t, ErrInvalidUUID.Error(), body.Message)
+		})
+
+		t.Run("should return resource not found", func(t *testing.T) {
+			dbClient := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+			defer func() { _ = dbClient.Close() }()
+
+			s := NewServer(Options{
+				Database: dbClient,
+				Logger:   zap.NewExample(),
+			})
+
+			res, err := testutils.Send(s.router, http.MethodPatch, "/medias/2028c250-ca4f-4dc4-b92c-ab56dbc5aa8b", CreateMedia{
+				Title: "foo",
+			})
+			assert.NoError(t, err)
+
+			var body util.ErrorResponse
+			_ = json.NewDecoder(res.Body).Decode(&body)
+
+			assert.Equal(t, 404, body.Code)
+			assert.Equal(t, ErrResourceNotFound.Error(), body.Message)
+		})
 	})
 }

--- a/api/stream.go
+++ b/api/stream.go
@@ -26,7 +26,7 @@ import (
 // @Header 200 {string} Content-Type "application/octet-stream"
 // @Param media_id path string true "Media identifier" validate(required)
 // @Param filename path string true "HLS filename" validate(required)
-// @Router /medias/{media_id}/stream/playlists/{filename} [get]
+// @Router /medias/{media_id}/stream/{filename} [get]
 func (s *Server) getMediaPlaylistFile(ctx *gin.Context) {
 	mediaUUID := ctx.Param("id")
 	filename := ctx.Param("filename")


### PR DESCRIPTION
fixes #98

Route "DELETE /medias/:id" should delete storage related to the media. Also, media deletion should be forbidden if the media has state "Processing".