### PR TITLE
Skip S3 storage driver test

### DIFF
--- a/storage_test.go
+++ b/storage_test.go
@@ -20,6 +20,10 @@ func TestStorage(t *testing.T) {
 	})
 
 	t.Run("should initialize S3 storage", func(t *testing.T) {
+		// Skipping as it continuously fail
+		// We should NOT rely on the network anymore
+		t.Skip()
+		
 		Config.Storage.S3 = config.S3Config{
 			Hostname:        "play.min.io",
 			AccessKeyID:     "Q3AM3UQ867SPQQA43P2F",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...

## Description

S3 storage driver test is failing continuously because of a remote Minio server error.