### PR TITLE
Remove unused codecov token from env

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,8 +56,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Test
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: go test -race -coverprofile=./c.out -covermode=atomic -v ./...
 
       - name: Report code coverage


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...

## Description

We moved from codecov to coveralls in December 2020. This token is not used anymore.